### PR TITLE
Add support for tainted nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 COPY cmd/storage-check /build
 WORKDIR /build
 ENV CGO_ENABLED=0
-RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin latest
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin v2.18.2
 RUN go build -v
 RUN go test -v
 RUN gosec -exclude=G107,G109,G304,G601 ./...

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This check follows the list of actions in order during the run of the check:
 1.  Looks for old storage check job, storage init job, and PVC belonging to this check and cleans them up.
 2.  Creates a PVC in the namespace and waits for the PVC to be ready.
 3.  Creates a storage init configuration, applies it to the namespace, and waits for the storage init job to come up and initialize the PVC with known data.
-4.  Determine which nodes in the cluster are going to run the storage check by auto-discovery or a list supplied nodes via the `CHECK_STORAGE_IGNORED_CHECK_NODES` and `CHECK_STORAGE_ALLOWED_CHECK_NODES` environment variables.
+4.  Determine which nodes in the cluster are going to run the storage check by auto-discovery or a list supplied nodes via the `CHECK_STORAGE_IGNORED_CHECK_NODES` and `CHECK_STORAGE_ALLOWED_CHECK_NODES` environment variables. Nodes with taints will not be included unless the toleration is configured in `CHECK_TOLERATIONS`.
 5.  For each node that needs a check, creates a storage check configuration, applies it to the namespace, and waits for the storage check job to start and validate the contents of storage on each desired node.
 6.  Tear everything down once completed.
 
@@ -55,6 +55,7 @@ This check follows the list of actions in order during the run of the check:
   - `CHECK_POD_CPU_LIMIT`: Check pod deployment CPU limit value. Calculated in decimal SI units `(75 = 75m cpu)`.
   - `CHECK_POD_MEM_REQUEST`: Check pod deployment memory request value. Calculated in binary SI units `(20 * 1024^2 = 20Mi memory)`.
   - `CHECK_POD_MEM_LIMIT`: Check pod deployment memory limit value. Calculated in binary SI units `(75 * 1024^2 = 75Mi memory)`.
+  - `CHECK_TOLERATIONS`: Check pod tolerations of node taints. In the format "key=value:effect,key=value:effect". By default no taints are tolerated.
   - `ADDITIONAL_ENV_VARS`: Comma separated list of `key=value` variables passed into the pod's containers.
   - `SHUTDOWN_GRACE_PERIOD`: Amount of time in seconds the shutdown will allow itself to clean up after an interrupt signal (default=`30s`).
   - `DEBUG`: Verbose debug logging.

--- a/cmd/storage-check/main.go
+++ b/cmd/storage-check/main.go
@@ -21,6 +21,7 @@ import (
 	kh "github.com/Comcast/kuberhealthy/v2/pkg/checks/external/checkclient"
 	"github.com/Comcast/kuberhealthy/v2/pkg/kubeClient"
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -109,6 +110,9 @@ var (
 	// Seconds allowed for the shutdown process to complete.
 	shutdownGracePeriodEnv = os.Getenv("SHUTDOWN_GRACE_PERIOD")
 	shutdownGracePeriod    time.Duration
+
+	tolerationsEnv = os.Getenv("CHECK_TOLERATIONS")
+	tolerations    []corev1.Toleration
 
 	// Time object used for the check.
 	now time.Time

--- a/cmd/storage-check/storage.go
+++ b/cmd/storage-check/storage.go
@@ -141,6 +141,7 @@ func initializeStorageConfig(jobName string, pvcName string) *batchv1.Job {
 					Name:         "data",
 					VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: pvc},
 				}},
+				Tolerations: tolerations,
 			},
 		},
 	}


### PR DESCRIPTION
Specify node taints to tolerate for the checks. Use the `CHECK_TOLERATIONS` environment variable in the format:

`key=value:NoSchedule, key=value:NoSchedule`